### PR TITLE
Make rom by passing elf through ihex format then elf32-littlearm

### DIFF
--- a/bundler-py/bundler.py
+++ b/bundler-py/bundler.py
@@ -66,15 +66,17 @@ def load_private_key(file):
     return serialization.load_pem_private_key(
         file.read(), password=None, backend=default_backend())
 
-
 def elf_to_rom(elf_filename):
-    with tempfile.NamedTemporaryFile() as tmp:
+    with tempfile.NamedTemporaryFile() as hex:
         normalized_file = os.path.abspath(elf_filename)
-        subprocess.check_call(['arm-none-eabi-objcopy', '-Obinary', '--gap-fill=0xff'] +
-                              [normalized_file, tmp.name])
+        subprocess.check_call(['arm-none-eabi-objcopy', '-Oihex'] + 
+                              [normalized_file, hex.name])
+        with tempfile.NamedTemporaryFile() as tmp:
+            subprocess.check_call(['arm-none-eabi-objcopy', '-Iihex', '-Obinary', '--gap-fill=0xff'] +
+                                  [hex.name, tmp.name])
 
-        tmp.seek(0)
-        return tmp.read()
+            tmp.seek(0)
+            return tmp.read()
 
 
 def write_layer(zip, contents):


### PR DESCRIPTION
When using arm-none-eabi-objcopy on tiny ELF files, the --gap-fill=0xff parameter for some reason decides to gap fill all the way from flash at 0x08000000 to RAM at 0x20000000, which results in a giant file. This does not happen for ELF files over a certain (unknown) size, such as those that call server_log or open_log_channel, which most probably do. 

The workaround is to call objcopy on the ELF file to turn it into a hex, then call objcopy on the hex file with the --gap-fill parameter to create the ROM.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [*] I acknowledge that all my contributions will be made under the project's license.
